### PR TITLE
Upgrade to 3.0.6, add delayElements(Scheduler) and unblock some tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 ext {
-    reactorVersion = "3.0.5.RELEASE"
+    reactorVersion = "3.0.6.RELEASE"
     baseScalaVersion = "2.11"
 }
 

--- a/src/main/scala/reactor/core/scala/publisher/Flux.scala
+++ b/src/main/scala/reactor/core/scala/publisher/Flux.scala
@@ -1054,6 +1054,20 @@ class Flux[T] private[publisher](private[publisher] val jFlux: JFlux[T]) extends
 
   /**
     * Delay each of this [[Flux]] elements ([[Subscriber.onNext]] signals)
+    * by a given duration, on a given [[Scheduler]].
+    *
+    * <p>
+    * <img class="marble" src="https://raw.githubusercontent.com/reactor/reactor-core/v3.0.5.RELEASE/src/docs/marble/delayonnext.png" alt="">
+    *
+    * @param delay duration to delay each [[Subscriber.onNext]] signal
+    * @param timer the [[Scheduler]] to use for delaying each signal
+    * @return a delayed [[Flux]]
+    * @see #delaySubscription(Duration) delaySubscription to introduce a delay at the beginning of the sequence only
+    */
+  final def delayElements(delay: Duration, timer: Scheduler) = Flux(jFlux.delayElements(delay, timer))
+
+  /**
+    * Delay each of this [[Flux]] elements ([[Subscriber.onNext]] signals)
     * by a given duration in milliseconds.
     *
     * <p>


### PR DESCRIPTION
This commit bumps the dependency to reactor-core to 3.0.6 and adds the
delayElements(Scheduler) overload to scala Flux.

Additionally, it modifies some tests that are using VirtualTimeScheduler
and were blocked due to the changes in how VirtualTimeScheduler now
interacts with the Schedulers factories and how some operators in core
default to Schedulers.parallel() instead of Schedulers.timer().